### PR TITLE
Fix depleteamount

### DIFF
--- a/rebalance/parallel/candidates.go
+++ b/rebalance/parallel/candidates.go
@@ -48,7 +48,7 @@ func (r *RebalanceParallel) canUseChannel(channel *glightning.PeerChannel) error
 	depleteAmount := util.Min(r.DepleteUpToAmount,
 		uint64(float64(channel.MilliSatoshiTotal)*r.DepleteUpToPercent))
 	r.Node.Logln(glightning.Debug, "depleteAmount:", depleteAmount)
-	if channel.SpendableMilliSatoshi < depleteAmount {
+	if channel.MilliSatoshiToUs < depleteAmount {
 		return util.ErrChannelDepleted
 	}
 


### PR DESCRIPTION
Spendable milisatoshi is capped at ~4.2m. to_us should be used there.